### PR TITLE
Request session restart

### DIFF
--- a/demo/src/example2.js
+++ b/demo/src/example2.js
@@ -13,7 +13,7 @@ import io from 'socket.io-client';
 import TutorialContainer from '../../src/TutorialContainer';
 import TutorialLayout from '../../src/TutorialLayout';
 import TutorialSelection from '../../src/TutorialSelection';
-import loadTutorials, { getTutorialsUrl } from '../../src/utils/loadTutorials';
+import loadTutorials from '../../src/utils/loadTutorials';
 
 let socket;
 let tutorials;
@@ -54,12 +54,22 @@ function renderTutorialContainer() {
       tutorial={tutorial}
       socket={socket}
     >
-      {({ completedSteps, currentStep, terminal }) => (
+      {({
+        completedSteps,
+        currentStep,
+        onSessionRestartAccepted,
+        onSessionRestartDeclined,
+        requestSessionRestart,
+        terminal,
+      }) => (
         <div>
           <TutorialLayout
             completedSteps={completedSteps}
             currentStep={currentStep}
+            onSessionRestartAccepted={onSessionRestartAccepted}
+            onSessionRestartDeclined={onSessionRestartDeclined}
             onShowAllTutorials={() => handleTutorialSelection(undefined)}
+            requestSessionRestart={requestSessionRestart}
             terminal={terminal}
             tutorial={tutorial}
           />

--- a/src/ReactTerminal.js
+++ b/src/ReactTerminal.js
@@ -36,6 +36,7 @@ export default class ReactTerminal extends Component {
   props: {
     columns: number,
     onInputLine: (string) => void,
+    onSessionEnd?: () => void,  // eslint-disable-line react/require-default-props
     rows: number,
     socket: any,
   }
@@ -128,6 +129,13 @@ export default class ReactTerminal extends Component {
 
     this.stream.on('data', (chunk) => {
       debug('Received chunk %o as string: %s', chunk, chunk.toString());
+    });
+
+    this.stream.on('end', () => {
+      debug('stream end');
+      if (this.props.onSessionEnd) {
+        this.props.onSessionEnd();
+      }
     });
 
     const userProvidedInput = this.stream.pipe(term).dom(this.terminalEl);

--- a/src/TutorialContainer.js
+++ b/src/TutorialContainer.js
@@ -19,6 +19,9 @@ const debug = mkDebug('FlightTutorials:TutorialContainer');
 type ChildrenPropType = ({
   completedSteps : Array<string>,
   currentStep: string,
+  onSessionRestartAccepted: () => void,
+  onSessionRestartDeclined: () => void,
+  requestSessionRestart: boolean,
   terminal : React$Element<*>,  // A ReactTerminal element.
 }) => React$Element<*>;
 
@@ -28,12 +31,16 @@ export default class TutorialContainer extends Component {
     this.state = {
       currentStep: this.props.tutorial.firstStep,
       completedSteps: [],
+      requestSessionRestart: false,
+      sessionId: 0,
     };
   }
 
   state: {
     currentStep: string,
     completedSteps: Array<string>,
+    requestSessionRestart: boolean,
+    sessionId: number,
   };
 
   props: {
@@ -55,6 +62,22 @@ export default class TutorialContainer extends Component {
     }
   }
 
+  handleSessionEnd = () => {
+    this.setState({ requestSessionRestart: true });
+  }
+
+  handleRestartSession = () => {
+    this.setState(state => ({
+      ...state,
+      sessionId: state.sessionId + 1,
+      requestSessionRestart: false,
+    }));
+  }
+
+  handleSessionRestartDeclined = () => {
+    this.setState({ requestSessionRestart: false });
+  }
+
   currentStep() : StepType {
     return this.props.tutorial.steps[this.state.currentStep];
   }
@@ -63,7 +86,9 @@ export default class TutorialContainer extends Component {
   render() {
     const terminal = (
       <ReactTerminal
+        key={this.state.sessionId}
         onInputLine={this.handleInputLine}
+        onSessionEnd={this.handleSessionEnd}
         socket={this.props.socket}
       />
     );
@@ -71,6 +96,9 @@ export default class TutorialContainer extends Component {
     return this.props.children({
       completedSteps: this.state.completedSteps,
       currentStep: this.state.currentStep,
+      onSessionRestartAccepted: this.handleRestartSession,
+      onSessionRestartDeclined: this.handleSessionRestartDeclined,
+      requestSessionRestart: this.state.requestSessionRestart,
       terminal,
     });
   }

--- a/src/TutorialContainer.test.js
+++ b/src/TutorialContainer.test.js
@@ -52,14 +52,39 @@ it('renders without crashing', () => {
 
 it('calls child function with expected arguments', () => {
   const childFunctionSpy = jest.fn().mockReturnValue(null);
-  shallow(
+  const wrapper = shallow(
     <TutorialContainer tutorial={tutorial} children={childFunctionSpy} socket={mockSocket} />,
   );
+  const instance = wrapper.instance();
+
+  // The flow type definition for `wrapper.instance()` returns a generic
+  // React$Component type, not the specific TutorialContainer type.  When that
+  // is fixed, we can remove these. See
+  // https://github.com/flowtype/flow-typed/issues/925
+  // $FlowFixMe
+  const onSessionRestartAccepted = instance.handleRestartSession;
+  // $FlowFixMe
+  const onSessionRestartDeclined = instance.handleSessionRestartDeclined;
+  // $FlowFixMe
+  const sessionId = instance.state.sessionId;
+  // $FlowFixMe
+  const onInputLine = instance.handleInputLine;
+  // $FlowFixMe
+  const onSessionEnd = instance.handleSessionEnd;
 
   expect(childFunctionSpy).toHaveBeenCalledWith({
     completedSteps: [],
     currentStep: tutorial.firstStep,
-    terminal: <ReactTerminal onInputLine={expect.anything()} socket={mockSocket} />,
+    onSessionRestartAccepted,
+    onSessionRestartDeclined,
+    requestSessionRestart: false,
+    terminal: <ReactTerminal
+      key={sessionId}
+      onInputLine={onInputLine}
+      onSessionEnd={onSessionEnd}
+      socket={mockSocket}
+    />,
+    // terminal: expect.anything()
   });
 });
 

--- a/src/TutorialLayout.js
+++ b/src/TutorialLayout.js
@@ -8,7 +8,9 @@
  *===========================================================================*/
 
 import React from 'react';
-import { Grid, Row, Col } from 'react-bootstrap';
+import { Grid, Row, Col, Button } from 'react-bootstrap';
+
+import StandardModal from 'flight-common/lib/components/StandardModal';
 
 import CloseButton from './CloseButton';
 import TutorialInfo from './TutorialInfo';
@@ -19,15 +21,21 @@ import type { TutorialType } from './types';
 type PropsType = {
   completedSteps : Array<string>,
   currentStep: string,
+  onSessionRestartAccepted: () => void,
+  onSessionRestartDeclined: () => void,
   onShowAllTutorials: () => void,
   terminal : React$Element<*>,  // A ReactTerminal element.
   tutorial: TutorialType,
+  requestSessionRestart: boolean,
 }
 
 const TutorialLayout = ({
   completedSteps,
   currentStep,
+  onSessionRestartAccepted,
+  onSessionRestartDeclined,
   onShowAllTutorials,
+  requestSessionRestart,
   terminal,
   tutorial,
 } : PropsType) => (
@@ -48,6 +56,22 @@ const TutorialLayout = ({
           />
         </Col>
         <Col xs={12} sm={12} md={8} lg={7} >
+          <StandardModal
+            buttons={
+              <Button
+                bsStyle="success"
+                onClick={onSessionRestartAccepted}
+              >
+                Restart
+              </Button>
+            }
+            show={requestSessionRestart}
+            onHide={onSessionRestartDeclined}
+            title="Your terminal session has been terminated"
+          >
+            Your terminal session has been terminated. Would you like to
+            restart it?
+          </StandardModal>
           {terminal}
         </Col>
       </Row>

--- a/src/TutorialLayout.test.js
+++ b/src/TutorialLayout.test.js
@@ -43,9 +43,12 @@ const renderTutorialLayout = () => (
   <TutorialLayout
     completedSteps={completedSteps}
     currentStep={currentStep}
+    onSessionRestartAccepted={() => {}}
+    onSessionRestartDeclined={() => {}}
     onShowAllTutorials={() => {}}
     terminal={dummyTerminal}
     tutorial={tutorial}
+    requestSessionRestart={false}
   />
 );
 

--- a/src/__snapshots__/TutorialLayout.test.js.snap
+++ b/src/__snapshots__/TutorialLayout.test.js.snap
@@ -140,6 +140,7 @@ exports[`renders correctly 1`] = `
       <div
         className="col-lg-7 col-md-8 col-sm-12 col-xs-12"
       >
+        <div />
         <div>
           dummy terminal
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -87,12 +87,22 @@ export default class extends Component {
 
     return (
       <TutorialContainer tutorial={tutorial} socket={this.socket}>
-        {({ completedSteps, currentStep, terminal }) => (
+        {({
+          completedSteps,
+          currentStep,
+          onSessionRestartAccepted,
+          onSessionRestartDeclined,
+          requestSessionRestart,
+          terminal,
+        }) => (
           <div>
             <TutorialLayout
               completedSteps={completedSteps}
               currentStep={currentStep}
+              onSessionRestartAccepted={onSessionRestartAccepted}
+              onSessionRestartDeclined={onSessionRestartDeclined}
               onShowAllTutorials={this.handleShowAllTutorials}
+              requestSessionRestart={requestSessionRestart}
               terminal={terminal}
               tutorial={tutorial}
             />

--- a/src/styles/_inbox.scss
+++ b/src/styles/_inbox.scss
@@ -14,3 +14,8 @@
     text-transform: uppercase;
     font-weight: 700;
 }
+
+BODY.modal-open {
+    overflow: visible !important;
+    padding-right: 0 !important;
+}


### PR DESCRIPTION
If the terminal session terminates, we now prompt the user for whether they wish to restart the session.

This is very useful for running Flight Tutorials on clusters launched by Flight Launch: the first time that a user logs on to the cluster they will be prompted to change their password and then there session will be
terminated.  We now ask if the user wants to restart their session will help step the user through what to do next.

Fixes #8 