### PR TITLE
Refocus terminal when session ends

### DIFF
--- a/demo/src/example2.js
+++ b/demo/src/example2.js
@@ -58,7 +58,7 @@ function renderTutorialContainer() {
         completedSteps,
         currentStep,
         onSessionRestartAccepted,
-        onSessionRestartDeclined,
+        onSessionRestartRequestClosed,
         requestSessionRestart,
         terminal,
       }) => (
@@ -67,7 +67,7 @@ function renderTutorialContainer() {
             completedSteps={completedSteps}
             currentStep={currentStep}
             onSessionRestartAccepted={onSessionRestartAccepted}
-            onSessionRestartDeclined={onSessionRestartDeclined}
+            onSessionRestartRequestClosed={onSessionRestartRequestClosed}
             onShowAllTutorials={() => handleTutorialSelection(undefined)}
             requestSessionRestart={requestSessionRestart}
             terminal={terminal}

--- a/src/ReactTerminal.js
+++ b/src/ReactTerminal.js
@@ -23,6 +23,7 @@ export default class ReactTerminal extends Component {
   };
 
   componentDidMount() {
+    debug('Mounted');
     this.terminalEl.tabIndex = 0;
     this.terminalEl.focus();
     this.connectTerminal();
@@ -30,6 +31,7 @@ export default class ReactTerminal extends Component {
   }
 
   componentWillUnmount() {
+    debug('Unmounting');
     this.endTerminalSession();
   }
 
@@ -161,6 +163,7 @@ export default class ReactTerminal extends Component {
   }
 
   focus() {
+    debug('Focusing terminal, %o', this.terminalEl);
     this.terminalEl.focus();
   }
 

--- a/src/ReactTerminal.js
+++ b/src/ReactTerminal.js
@@ -24,10 +24,17 @@ export default class ReactTerminal extends Component {
 
   componentDidMount() {
     debug('Mounted');
-    this.terminalEl.tabIndex = 0;
-    this.terminalEl.focus();
     this.connectTerminal();
     this.createTerminalSession();
+    // FSR when restarting a terminal session, that is umounting one
+    // ReactTerminal instance and mouting a new ReactTerminal instance, we
+    // need a setTimeout of 150ms before we are able to focus the terminal.
+    //
+    // I have no idea why this would be the case.  But the worst that could
+    // happen here is that the user has to click on the terminal before it
+    // receives any input.
+    this.focus();
+    setTimeout(() => this.focus(), 150);
   }
 
   componentWillUnmount() {
@@ -175,6 +182,7 @@ export default class ReactTerminal extends Component {
           className="flight-ReactTerminal"
           data-columns={this.props.columns}
           data-rows={this.props.rows}
+          tabIndex={0}
         />
       </div>
     );

--- a/src/ReactTerminal.js
+++ b/src/ReactTerminal.js
@@ -160,6 +160,10 @@ export default class ReactTerminal extends Component {
     this.stream.end();
   }
 
+  focus() {
+    this.terminalEl.focus();
+  }
+
   render() {
     return (
       <div>

--- a/src/ReactTerminal.js
+++ b/src/ReactTerminal.js
@@ -182,7 +182,7 @@ export default class ReactTerminal extends Component {
           className="flight-ReactTerminal"
           data-columns={this.props.columns}
           data-rows={this.props.rows}
-          tabIndex={0}
+          tabIndex={0}  // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
         />
       </div>
     );

--- a/src/TutorialContainer.js
+++ b/src/TutorialContainer.js
@@ -65,10 +65,12 @@ export default class TutorialContainer extends Component {
   }
 
   handleSessionEnd = () => {
+    debug('Session eneded. Requesting restart');
     this.setState({ requestSessionRestart: true });
   }
 
   handleSessionRestartAccepted = () => {
+    debug('Restarting session');
     this.setState(state => ({
       ...state,
       sessionId: state.sessionId + 1,
@@ -77,6 +79,7 @@ export default class TutorialContainer extends Component {
   }
 
   handleSessionRestartRequestClosed = () => {
+    debug('Closing session restart request.');
     this.setState({ requestSessionRestart: false });
     this.terminal.focus();
   }

--- a/src/TutorialContainer.js
+++ b/src/TutorialContainer.js
@@ -81,7 +81,6 @@ export default class TutorialContainer extends Component {
   handleSessionRestartRequestClosed = () => {
     debug('Closing session restart request.');
     this.setState({ requestSessionRestart: false });
-    this.terminal.focus();
   }
 
   currentStep() : StepType {

--- a/src/TutorialContainer.js
+++ b/src/TutorialContainer.js
@@ -49,6 +49,8 @@ export default class TutorialContainer extends Component {
     tutorial: TutorialType,
   };
 
+  terminal: ReactTerminal;
+
   handleInputLine = (line: string) => {
     const match = findMatch(this.currentStep().matches, line);
     if (match == null) { return; }
@@ -76,6 +78,7 @@ export default class TutorialContainer extends Component {
 
   handleSessionRestartRequestClosed = () => {
     this.setState({ requestSessionRestart: false });
+    this.terminal.focus();
   }
 
   currentStep() : StepType {
@@ -87,6 +90,7 @@ export default class TutorialContainer extends Component {
     const terminal = (
       <ReactTerminal
         key={this.state.sessionId}
+        ref={(term) => { this.terminal = term; }}
         onInputLine={this.handleInputLine}
         onSessionEnd={this.handleSessionEnd}
         socket={this.props.socket}

--- a/src/TutorialContainer.js
+++ b/src/TutorialContainer.js
@@ -20,7 +20,7 @@ type ChildrenPropType = ({
   completedSteps : Array<string>,
   currentStep: string,
   onSessionRestartAccepted: () => void,
-  onSessionRestartDeclined: () => void,
+  onSessionRestartRequestClosed: () => void,
   requestSessionRestart: boolean,
   terminal : React$Element<*>,  // A ReactTerminal element.
 }) => React$Element<*>;
@@ -66,7 +66,7 @@ export default class TutorialContainer extends Component {
     this.setState({ requestSessionRestart: true });
   }
 
-  handleRestartSession = () => {
+  handleSessionRestartAccepted = () => {
     this.setState(state => ({
       ...state,
       sessionId: state.sessionId + 1,
@@ -74,7 +74,7 @@ export default class TutorialContainer extends Component {
     }));
   }
 
-  handleSessionRestartDeclined = () => {
+  handleSessionRestartRequestClosed = () => {
     this.setState({ requestSessionRestart: false });
   }
 
@@ -96,8 +96,8 @@ export default class TutorialContainer extends Component {
     return this.props.children({
       completedSteps: this.state.completedSteps,
       currentStep: this.state.currentStep,
-      onSessionRestartAccepted: this.handleRestartSession,
-      onSessionRestartDeclined: this.handleSessionRestartDeclined,
+      onSessionRestartAccepted: this.handleSessionRestartAccepted,
+      onSessionRestartRequestClosed: this.handleSessionRestartRequestClosed,
       requestSessionRestart: this.state.requestSessionRestart,
       terminal,
     });

--- a/src/TutorialContainer.test.js
+++ b/src/TutorialContainer.test.js
@@ -62,9 +62,9 @@ it('calls child function with expected arguments', () => {
   // is fixed, we can remove these. See
   // https://github.com/flowtype/flow-typed/issues/925
   // $FlowFixMe
-  const onSessionRestartAccepted = instance.handleRestartSession;
+  const onSessionRestartAccepted = instance.handleSessionRestartAccepted;
   // $FlowFixMe
-  const onSessionRestartDeclined = instance.handleSessionRestartDeclined;
+  const onSessionRestartRequestClosed = instance.handleSessionRestartRequestClosed;
   // $FlowFixMe
   const sessionId = instance.state.sessionId;
   // $FlowFixMe
@@ -76,7 +76,7 @@ it('calls child function with expected arguments', () => {
     completedSteps: [],
     currentStep: tutorial.firstStep,
     onSessionRestartAccepted,
-    onSessionRestartDeclined,
+    onSessionRestartRequestClosed,
     requestSessionRestart: false,
     terminal: <ReactTerminal
       key={sessionId}

--- a/src/TutorialContainer.test.js
+++ b/src/TutorialContainer.test.js
@@ -80,6 +80,7 @@ it('calls child function with expected arguments', () => {
     requestSessionRestart: false,
     terminal: <ReactTerminal
       key={sessionId}
+      ref={expect.any(Function)}
       onInputLine={onInputLine}
       onSessionEnd={onSessionEnd}
       socket={mockSocket}

--- a/src/TutorialLayout.js
+++ b/src/TutorialLayout.js
@@ -22,7 +22,7 @@ type PropsType = {
   completedSteps : Array<string>,
   currentStep: string,
   onSessionRestartAccepted: () => void,
-  onSessionRestartDeclined: () => void,
+  onSessionRestartRequestClosed: () => void,
   onShowAllTutorials: () => void,
   terminal : React$Element<*>,  // A ReactTerminal element.
   tutorial: TutorialType,
@@ -33,7 +33,7 @@ const TutorialLayout = ({
   completedSteps,
   currentStep,
   onSessionRestartAccepted,
-  onSessionRestartDeclined,
+  onSessionRestartRequestClosed,
   onShowAllTutorials,
   requestSessionRestart,
   terminal,
@@ -66,7 +66,7 @@ const TutorialLayout = ({
               </Button>
             }
             show={requestSessionRestart}
-            onHide={onSessionRestartDeclined}
+            onHide={onSessionRestartRequestClosed}
             title="Your terminal session has been terminated"
           >
             Your terminal session has been terminated. Would you like to

--- a/src/TutorialLayout.test.js
+++ b/src/TutorialLayout.test.js
@@ -44,7 +44,7 @@ const renderTutorialLayout = () => (
     completedSteps={completedSteps}
     currentStep={currentStep}
     onSessionRestartAccepted={() => {}}
-    onSessionRestartDeclined={() => {}}
+    onSessionRestartRequestClosed={() => {}}
     onShowAllTutorials={() => {}}
     terminal={dummyTerminal}
     tutorial={tutorial}

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default class extends Component {
           completedSteps,
           currentStep,
           onSessionRestartAccepted,
-          onSessionRestartDeclined,
+          onSessionRestartRequestClosed,
           requestSessionRestart,
           terminal,
         }) => (
@@ -100,7 +100,7 @@ export default class extends Component {
               completedSteps={completedSteps}
               currentStep={currentStep}
               onSessionRestartAccepted={onSessionRestartAccepted}
-              onSessionRestartDeclined={onSessionRestartDeclined}
+              onSessionRestartRequestClosed={onSessionRestartRequestClosed}
               onShowAllTutorials={this.handleShowAllTutorials}
               requestSessionRestart={requestSessionRestart}
               terminal={terminal}


### PR DESCRIPTION
When the terminal session ends, the user is asked if they wish to start another session.  Once that dialog closes we should refocus the terminal so that any input is directed to it.  This is particularly import for Flight Launch clusters as the user will need to enter their password again.